### PR TITLE
ci: upload ceremony file to storage

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -48,7 +48,7 @@ env:
   ceremony_source: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_21.ptau
   s3_bucket_path: proving-key
   circuit_file: workflow/build/proof_main.zkey
-  storage_url: https://ceremony.codex.storage
+  storage_url: https://circuit.codex.storage
   s3_endpoint: ${{ secrets.S3_ENDPOINT }}
   s3_bucket: ${{ secrets.S3_BUCKET }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,6 +46,15 @@ env:
   nim_version: 1.6.14
   nodejs_version: 18.15
   ceremony_source: https://storage.googleapis.com/zkevm/ptau/powersOfTau28_hez_final_21.ptau
+  s3_bucket_path: proving-key
+  circuit_file: workflow/build/proof_main.zkey
+  storage_url: https://ceremony.codex.storage
+  s3_endpoint: ${{ secrets.S3_ENDPOINT }}
+  s3_bucket: ${{ secrets.S3_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+
 jobs:
   build:
     defaults:
@@ -129,13 +138,15 @@ jobs:
 
       - name: Upload to storage
         run: |
-          hash=($(shasum -a 256 ${{ env.CIRCUIT_FILE }}))
-          aws s3 cp ${{ env.CIRCUIT_FILE }} s3://${{ env.AWS_S3_BUCKET }}/${hash} --endpoint-url ${AWS_S3_ENDPOINT}
-          aws s3 cp ${{ env.CIRCUIT_FILE }} s3://${{ env.AWS_S3_BUCKET }}/`basename ${{ env.CIRCUIT_FILE }}` --endpoint-url ${AWS_S3_ENDPOINT}
+          # Variables
+          hash=($(shasum -a 256 ${{ env.circuit_file }}))
+          [[ -z "${{ env.s3_bucket_path}}" ]] && storage_file="${hash}" || storage_file="${{ env.s3_bucket_path}}/${hash}"
+          echo "storage_file=${storage_file}" >>$GITHUB_ENV
+          # Upload
+          aws s3 cp ${{ env.circuit_file }} s3://${{ env.s3_bucket }}/${storage_file} --endpoint-url ${{ env.s3_endpoint }}
+
+      - name: Show download URL
+        run: |
+          echo "Download URL: ${{ env.download_url }}"
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-          AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          CIRCUIT_FILE: workflow/build/proof_main.zkey
+          download_url: ${{ format('{0}/{1}', env.storage_url, env.storage_file) }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -126,3 +126,16 @@ jobs:
           name: circuit-assets
           path: workflow/build
           retention-days: 5
+
+      - name: Upload to storage
+        run: |
+          hash=($(shasum -a 256 ${{ env.CIRCUIT_FILE }}))
+          aws s3 cp ${{ env.CIRCUIT_FILE }} s3://${{ env.AWS_S3_BUCKET }}/${hash} --endpoint-url ${AWS_S3_ENDPOINT}
+          aws s3 cp ${{ env.CIRCUIT_FILE }} s3://${{ env.AWS_S3_BUCKET }}/`basename ${{ env.CIRCUIT_FILE }}` --endpoint-url ${AWS_S3_ENDPOINT}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          CIRCUIT_FILE: workflow/build/proof_main.zkey


### PR DESCRIPTION
This PR add a step to upload ceremony file to storage in two names
 - `proof_main.zkey`
 - `55c969da98f17fc878e5aee610a702e9cb1a1e5b3b0f2ebb26aef9690a96eafa` (sha256 from the first file)

After upload, file can be downloaded using the following URL's
```
curl https://ceremony.codex.storage/proof_main.zkey -o proof_main.zkey

curl https://ceremony.codex.storage/55c969da98f17fc878e5aee610a702e9cb1a1e5b3b0f2ebb26aef9690a96eafa -o proof_main.zkey.hash
```

Closes https://github.com/codex-storage/infra-codex/issues/123