### PR TITLE
ci: add zkey hash uploaded

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -49,11 +49,6 @@ env:
   s3_bucket_path: proving-key
   circuit_file: workflow/build/proof_main.zkey
   storage_url: https://circuit.codex.storage
-  s3_endpoint: ${{ secrets.S3_ENDPOINT }}
-  s3_bucket: ${{ secrets.S3_BUCKET }}
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
 
 jobs:
   build:
@@ -129,14 +124,13 @@ jobs:
           cd ..
           snarkjs groth16 prove proof_main.zkey witness.wtns proof.json public.json
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: circuit-assets
-          path: workflow/build
-          retention-days: 5
-
       - name: Upload to storage
+        env:
+          s3_endpoint: ${{ secrets.S3_ENDPOINT }}
+          s3_bucket: ${{ secrets.S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: |
           # Variables
           hash=($(shasum -a 256 ${{ env.circuit_file }}))
@@ -144,9 +138,18 @@ jobs:
           echo "storage_file=${storage_file}" >>$GITHUB_ENV
           # Upload
           aws s3 cp ${{ env.circuit_file }} s3://${{ env.s3_bucket }}/${storage_file} --endpoint-url ${{ env.s3_endpoint }}
+          # Add hash to the assets
+          echo "\"${hash}\"" > workflow/build/zkey_hash.json
 
       - name: Show download URL
         run: |
           echo "Download URL: ${{ env.download_url }}"
         env:
           download_url: ${{ format('{0}/{1}', env.storage_url, env.storage_file) }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: circuit-assets
+          path: workflow/build
+          retention-days: 5


### PR DESCRIPTION
@veaceslavdoina I have moved the S3's secrets only to the upload step. We don't need to expose it to the other steps. Even unlikely, the secrets could leak through the external Github Actions...

This adds the `zkey_hash.json` file, which contains the SHA256 hash under which it is uploaded to S3. In future, this will be changed for Codex's hash.