### PR TITLE
Switch from zip to tar.gz

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -51,7 +51,7 @@ env:
   constraints_file: workflow/build/proof_main.r1cs
   wasm_file: workflow/build/proof_main_js/proof_main.wasm
   verification_key_file: workflow/build/proof_main_verification_key.json
-  zip_file: workflow/build/proof_circuit.zip
+  archive_file: workflow/build/proof_circuit.tar.gz
   storage_url: https://circuit.codex.storage
 
 jobs:
@@ -136,14 +136,14 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: |
-          # Zip
-          zip -qj ${{ env.zip_file }} ${{ env.circuit_file }} ${{ env.constraints_file }} ${{ env.wasm_file }} ${{ env.verification_key_file }}
+          # Archive
+          tar -czvf ${{ env.archive_file }} ${{ env.circuit_file }} ${{ env.constraints_file }} ${{ env.wasm_file }} ${{ env.verification_key_file }}
           # Variables
-          hash=($(shasum -a 256 ${{ env.zip_file }}))
+          hash=($(shasum -a 256 ${{ env.archive_file }}))
           [[ -z "${{ env.s3_bucket_path}}" ]] && storage_file="${hash}" || storage_file="${{ env.s3_bucket_path}}/${hash}"
           echo "storage_file=${storage_file}" >>$GITHUB_ENV
           # Upload
-          aws s3 cp ${{ env.zip_file }} s3://${{ env.s3_bucket }}/${storage_file} --endpoint-url ${{ env.s3_endpoint }}
+          aws s3 cp ${{ env.archive_file }} s3://${{ env.s3_bucket }}/${storage_file} --endpoint-url ${{ env.s3_endpoint }}
           # Add hash to the assets
           echo "\"${hash}\"" > workflow/build/zkey_hash.json
 


### PR DESCRIPTION
As a part of https://github.com/codex-storage/nim-codex/pull/882, we decided to switch from zip archives to tar.gz one.

This PR updates the CI to create a new archive type.

As a result, we will have different files and hashes, so it will be required to
- Re-generate circuits for all existing networks
- Re-upload them to the [`codex-contracts-eth`](https://github.com/codex-storage/codex-contracts-eth/tree/master/verifier/networks) repository
- Re-deploy involved smart contracts