### PR TITLE
Make flat tar.gz

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -137,7 +137,9 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         run: |
           # Archive
-          tar czvf ${{ env.archive_file }} ${{ env.circuit_file }} ${{ env.constraints_file }} ${{ env.wasm_file }} ${{ env.verification_key_file }}
+          mkdir archive
+          mv ${{ env.circuit_file }} ${{ env.constraints_file }} ${{ env.wasm_file }} ${{ env.verification_key_file }} archive
+          tar czvf ${{ env.archive_file }} -C archive .
           # Variables
           hash=($(shasum -a 256 ${{ env.archive_file }}))
           [[ -z "${{ env.s3_bucket_path}}" ]] && storage_file="${hash}" || storage_file="${{ env.s3_bucket_path}}/${hash}"


### PR DESCRIPTION
When we used zip (#11) we had a flat archive structure, without folders. And we need the same with tar.gz.