### PR TITLE
ci: install custom rust version

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -93,6 +93,13 @@ jobs:
           crate: circom-witnesscalc
           git: https://github.com/iden3/circom-witnesscalc.git
 
+      - name: Setup Circom-witnesscalc/build-circuit
+        uses: baptiste0928/cargo-install@v3
+        with:
+          cache-key: 'invalid-cache-please'
+          crate: build-circuit
+          git: https://github.com/iden3/circom-witnesscalc.git
+
       - name: Setup Nim
         uses: jiro4989/setup-nim-action@v2
         with:


### PR DESCRIPTION
PR add a step to install a custom Rust version, because we are using [BuildJet runners](https://buildjet.com/for-github-actions/docs/runners/images) which are still on Ubuntu 22.04 and uses rust `1.78.0`.

There is not yet an an official action for that - [Create official Rust setup GitHub Action? #3409](https://github.com/rust-lang/rustup/issues/3409) and we rely on [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain).

Also, to be able to install [iden3/circom-witnesscalc](https://github.com/iden3/circom-witnesscalc) it was required to install additional packages. And we also needs to install `build-circuit` in a separate step.